### PR TITLE
Make object.WithConfigData() ignore the existing config file content

### DIFF
--- a/core/commands/node_print_schedule.go
+++ b/core/commands/node_print_schedule.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"opensvc.com/opensvc/core/client"
+	"opensvc.com/opensvc/core/clientcontext"
+	"opensvc.com/opensvc/core/flag"
+	"opensvc.com/opensvc/core/object"
+	"opensvc.com/opensvc/core/output"
+	"opensvc.com/opensvc/core/rawconfig"
+	"opensvc.com/opensvc/core/schedule"
+)
+
+type (
+	// NodePrintSchedule is the cobra flag set of the print schedule command.
+	NodePrintSchedule struct {
+		OptsGlobal
+	}
+)
+
+// Init configures a cobra command and adds it to the parent command.
+func (t *NodePrintSchedule) Init(parent *cobra.Command) {
+	cmd := t.cmd()
+	parent.AddCommand(cmd)
+	flag.Install(cmd, t)
+}
+
+func (t *NodePrintSchedule) cmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "schedule",
+		Short:   "Print selected objects scheduling table",
+		Aliases: []string{"schedul", "schedu", "sched", "sche", "sch", "sc"},
+		Run: func(cmd *cobra.Command, args []string) {
+			t.run()
+		},
+	}
+}
+
+func (t *NodePrintSchedule) extract(c *client.T) schedule.Table {
+	if t.Local {
+		return t.extractLocal()
+	}
+	if data, err := t.extractFromDaemon(c); err == nil {
+		return data
+	}
+	if clientcontext.IsSet() {
+		log.Error().Msg("can not fetch daemon data")
+		return schedule.NewTable()
+	}
+	return t.extractLocal()
+}
+
+func (t *NodePrintSchedule) extractLocal() schedule.Table {
+	data := schedule.NewTable()
+	obj, err := object.NewNode()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(1)
+	}
+	table := obj.PrintSchedule()
+	data = data.Add(table)
+	return data
+}
+
+func (t *NodePrintSchedule) extractFromDaemon(c *client.T) (schedule.Table, error) {
+	data := schedule.NewTable()
+	req := c.NewGetSchedules()
+	b, err := req.Do()
+	if err != nil {
+		return data, err
+	}
+	err = json.Unmarshal(b, &data)
+	if err != nil {
+		log.Debug().Err(err).Msg("unmarshal GET /schedules")
+		return data, err
+	}
+	return data, nil
+}
+
+func (t *NodePrintSchedule) run() {
+	c, err := client.New(client.WithURL(t.Server))
+	if err != nil {
+		log.Error().Err(err).Msg("")
+		os.Exit(1)
+	}
+	data := t.extract(c)
+
+	output.Renderer{
+		Format:   t.Format,
+		Color:    t.Color,
+		Data:     data,
+		Colorize: rawconfig.Colorize,
+		HumanRenderer: func() string {
+			return data.Render()
+		},
+	}.Print()
+}

--- a/core/commands/object_edit_config.go
+++ b/core/commands/object_edit_config.go
@@ -111,7 +111,7 @@ func fetchConfig(p path.T, c *client.T) (s string, err error) {
 
 func pushConfig(p path.T, fName string, c *client.T) (err error) {
 	var cfg *xconfig.T
-	if cfg, err = xconfig.NewObject(fName); err != nil {
+	if cfg, err = xconfig.NewObject("", fName); err != nil {
 		return err
 	}
 	req := c.NewPostObjectCreate()

--- a/core/entrypoints/create/main.go
+++ b/core/entrypoints/create/main.go
@@ -215,7 +215,7 @@ func rawFromConfigURI(p path.T, u uri.T) (Pivot, error) {
 
 func rawFromConfigFile(p path.T, fpath string) (Pivot, error) {
 	pivot := make(Pivot)
-	c, err := xconfig.NewObject(fpath)
+	c, err := xconfig.NewObject("", fpath)
 	if err != nil {
 		return pivot, err
 	}

--- a/core/object/core_config.go
+++ b/core/object/core_config.go
@@ -33,17 +33,20 @@ func (t *core) reloadConfig() error {
 
 func (t *core) loadConfig(referrer xconfig.Referrer) error {
 	var err error
-	var sources []interface{}
+	var sources []any
+	cf := t.ConfigFile()
 	if t.configData != nil {
-		sources = append(sources, t.configData)
+		sources = []any{t.configData}
+	} else {
+		sources = []any{cf}
 	}
-	if t.config, err = xconfig.NewObject(t.ConfigFile(), sources...); err != nil {
+	if t.config, err = xconfig.NewObject(cf, sources...); err != nil {
 		return err
 	}
 	t.config.Path = t.path
 	t.config.Referrer = referrer
 	t.config.NodeReferrer, err = t.Node()
-	return err
+	return nil
 }
 
 func (t core) Config() *xconfig.T {

--- a/core/object/node_config.go
+++ b/core/object/node_config.go
@@ -32,16 +32,21 @@ func (t *Node) ClusterConfigFile() string {
 }
 
 func (t *Node) loadConfig() error {
-	var err error
-	if t.config, err = xconfig.NewObject(t.ConfigFile()); err != nil {
+	nodeConfigFile := t.ConfigFile()
+	if config, err := xconfig.NewObject(nodeConfigFile, nodeConfigFile); err != nil {
 		return err
+	} else {
+		t.config = config
+		t.config.Referrer = t
 	}
-	t.config.Referrer = t
-	if t.mergedConfig, err = xconfig.NewObject(t.ClusterConfigFile(), t.ConfigFile()); err != nil {
+	clusterConfigFile := t.ClusterConfigFile()
+	if config, err := xconfig.NewObject(clusterConfigFile, clusterConfigFile, nodeConfigFile); err != nil {
 		return err
+	} else {
+		t.mergedConfig = config
+		t.mergedConfig.Referrer = t
 	}
-	t.mergedConfig.Referrer = t
-	return err
+	return nil
 }
 
 func (t Node) Config() *xconfig.T {

--- a/core/object/node_print_schedule.go
+++ b/core/object/node_print_schedule.go
@@ -1,0 +1,92 @@
+package object
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"opensvc.com/opensvc/core/driver"
+	"opensvc.com/opensvc/core/resource"
+	"opensvc.com/opensvc/core/resourceid"
+	"opensvc.com/opensvc/core/schedule"
+	"opensvc.com/opensvc/util/file"
+	"opensvc.com/opensvc/util/hostname"
+	"opensvc.com/opensvc/util/key"
+)
+
+// PrintSchedule display the object scheduling table
+func (t *Node) PrintSchedule() schedule.Table {
+	return t.Schedules()
+}
+
+func (t *Node) lastFilepath(action string, rid string, base string) string {
+	base = "last_" + base
+	if rid != "" {
+		base = base + "_" + rid
+	}
+	return filepath.Join(t.VarDir(), "scheduler", base)
+}
+
+func (t *Node) lastSuccessFilepath(action string, rid string, base string) string {
+	return filepath.Join(t.lastFilepath(action, rid, base) + ".success")
+}
+
+func (t *Node) loadLast(action string, rid string, base string) time.Time {
+	fpath := t.lastFilepath(action, rid, base)
+	return file.ModTime(fpath)
+}
+
+func (t *Node) newScheduleEntry(action string, keyStr string, base string) schedule.Entry {
+	k := key.Parse(keyStr)
+	def, err := t.config.GetStringStrict(k)
+	if err != nil {
+		panic(err)
+	}
+	return schedule.Entry{
+		Node:       hostname.Hostname(),
+		Action:     action,
+		Last:       t.loadLast(action, "", base),
+		Key:        k.String(),
+		Definition: def,
+	}
+}
+
+func (t *Node) Schedules() schedule.Table {
+	table := schedule.NewTable(
+		t.newScheduleEntry("pushasset", "asset.schedule", "asset_push"),
+		t.newScheduleEntry("reboot", "asset.schedule", "auto_reboot"),
+		t.newScheduleEntry("checks", "checks.schedule", "checks_push"),
+		t.newScheduleEntry("compliance_auto", "compliance.schedule", "comp_check"),
+		t.newScheduleEntry("dequeue_actions", "dequeue_actions.schedule", "dequeue_actions_push"),
+		t.newScheduleEntry("pushdisks", "disks.schedule", "disks_push"),
+		t.newScheduleEntry("pushpkg", "packages.schedule", "packages_push"),
+		t.newScheduleEntry("pushpatch", "patches.schedule", "patches_push"),
+		t.newScheduleEntry("rotate_root_pw", "rotate_root_pw.schedule", "rotate_root_pw"),
+		t.newScheduleEntry("pushstats", "stats.schedule", "stats_push"),
+		t.newScheduleEntry("collect_stats", "stats_collection.schedule", "stats_collection_push"),
+		t.newScheduleEntry("sysreport", "sysreport.schedule", "sysreport_push"),
+	)
+	type scheduleOptioner interface {
+		ScheduleOptions() resource.ScheduleOptions
+	}
+	for _, s := range t.config.SectionStrings() {
+		rid, err := resourceid.Parse(s)
+		if err != nil {
+			continue
+		}
+		switch rid.DriverGroup() {
+		case driver.GroupArray:
+		case driver.GroupSwitch:
+		case driver.GroupBackup:
+		default:
+			// no schedule
+			continue
+		}
+		drvType := t.config.GetString(key.T{s, "type"})
+		base := fmt.Sprintf("%s_%s_push", s, drvType)
+		action := "push" + drvType
+		e := t.newScheduleEntry(action, key.T{s, "schedule"}.String(), base)
+		table = table.Add(e)
+	}
+	return table
+}

--- a/core/xconfig/object.go
+++ b/core/xconfig/object.go
@@ -7,19 +7,30 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NewObject configures and returns a T instance pointer
-func NewObject(p string, others ...interface{}) (t *T, err error) {
-	cf := filepath.FromSlash(p)
-	t = &T{
-		ConfigFilePath: cf,
+//
+// NewObject configures and returns a T instance pointer.
+// The first argument is the path of the configuration file to write to.
+//
+// The path must be repeated as one of the following sources to read it.
+// Accepted sources are []byte in ini format or a configuration file path
+// containing ini formatted data.
+//
+func NewObject(p string, sources ...any) (*T, error) {
+	t := &T{
+		ConfigFilePath: filepath.FromSlash(p),
 	}
-	t.file, err = ini.LoadSources(ini.LoadOptions{
+	loadOptions := ini.LoadOptions{
 		Loose:                      true,
 		AllowPythonMultilineValues: true,
 		SpaceBeforeInlineComment:   true,
-	}, cf, others...)
-	if err != nil {
-		return nil, errors.Wrap(err, "load config error")
+	}
+	if len(sources) == 0 {
+		sources = append(sources, []byte{})
+	}
+	if f, err := ini.LoadSources(loadOptions, sources[0], sources[1:]...); err != nil {
+		return nil, errors.Wrap(err, "load config sources error")
+	} else {
+		t.file = f
 	}
 	return t, nil
 }

--- a/drivers/poolvirtual/main.go
+++ b/drivers/poolvirtual/main.go
@@ -72,7 +72,8 @@ func (t *T) translate(name string, size float64, shared bool) ([]string, error) 
 	if template.Kind != kind.Vol {
 		return nil, errors.Errorf("template object %s is not a vol", template)
 	}
-	config, err := xconfig.NewObject(template.ConfigFile())
+	cf := template.ConfigFile()
+	config, err := xconfig.NewObject("", cf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
xconfig.NewObject now has its first argument interpreted as the config
file path, not considered to be loaded.

the following arguments are sources to load, so the cf must be passed
again to load it.

Update the calling codepath to convert to this policy.