### PR TITLE
Fix possible daemon restart hang

### DIFF
--- a/daemon/daemonapi/get_daemon_status.go
+++ b/daemon/daemonapi/get_daemon_status.go
@@ -3,11 +3,43 @@ package daemonapi
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
+	"time"
 
 	"opensvc.com/opensvc/daemon/daemondata"
 )
 
+type (
+	subRefresh struct {
+		*sync.Mutex
+		updated time.Time
+	}
+)
+
+const (
+	// subRefreshInterval defines the maximum duration before next SubRefresh
+	subRefreshInterval = 2 * time.Second
+)
+
+var (
+	subRefreshed = subRefresh{Mutex: &sync.Mutex{}}
+)
+
+// GetDaemonStatus returns daemon data status
+//
+// When sub data hIt forces refreshing of sub data every 1
 func (a *DaemonApi) GetDaemonStatus(w http.ResponseWriter, r *http.Request, params GetDaemonStatusParams) {
+	now := time.Now()
+	subRefreshed.Lock()
+	if now.After(subRefreshed.updated.Add(subRefreshInterval)) {
+		bus := daemondata.BusFromContext(r.Context())
+		if err := daemondata.SubRefresh(bus); err != nil {
+
+		}
+		subRefreshed.updated = now
+	}
+	subRefreshed.Unlock()
+
 	databus := daemondata.FromContext(r.Context())
 	status := databus.GetStatus()
 	if params.Selector != nil {

--- a/daemon/daemondata/apply_commit.go
+++ b/daemon/daemondata/apply_commit.go
@@ -19,6 +19,7 @@ import (
 //	   drop patch queue entries that have been applied on all peers
 //
 //	  when hb mode is not patch
+//		   increase gen when pending ops exists
 //		   drop pending ops
 //		   drop patch queue
 func (d *data) commitPendingOps() (changes bool) {
@@ -31,6 +32,11 @@ func (d *data) commitPendingOps() (changes bool) {
 		d.movePendingOpsToPatchQueue()
 		d.purgeAppliedPatchQueue()
 	} else {
+		if changes {
+			// increase gen (we have changes that need to be sent before switching to patch mode)
+			d.gen++
+			d.pending.Cluster.Node[d.localNode].Status.Gen[d.localNode] = d.gen
+		}
 		d.pendingOps = []jsondelta.Operation{}
 		d.patchQueue = make(patchQueue)
 	}

--- a/daemon/daemondata/data.go
+++ b/daemon/daemondata/data.go
@@ -183,7 +183,7 @@ func run(ctx context.Context, cmdC <-chan interface{}, hbRecvQ <-chan *hbtype.Ms
 			}
 			if needMessage || d.needMsg {
 				hbMsgType := d.hbMsgType
-				if err := d.queueNewHbMsg(); err != nil {
+				if err := d.queueNewHbMsg(ctx); err != nil {
 					d.log.Error().Err(err).Msg("queue hb message")
 				} else {
 					d.needMsg = false

--- a/daemon/daemondata/data.go
+++ b/daemon/daemondata/data.go
@@ -58,6 +58,10 @@ type (
 		//   apply full, apply patch, or during commitPendingOps
 		hbGens map[string]map[string]uint64
 
+		// hbPatchMsgUpdated track last applied kind patch hb message
+		// It is used to drop outdated patch messages
+		hbPatchMsgUpdated map[string]time.Time
+
 		// needMsg is set to true when a peer node doesn't know localnode current data gen
 		// set to false after a hb message is created
 		needMsg bool

--- a/daemon/daemondata/data_init.go
+++ b/daemon/daemondata/data_init.go
@@ -3,6 +3,7 @@ package daemondata
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	"opensvc.com/opensvc/core/cluster"
 	"opensvc.com/opensvc/core/instance"
@@ -59,6 +60,7 @@ func newData(counterCmd chan<- interface{}) *data {
 		subHbMode:          map[string]string{localNode: "undef"},
 		hbMsgType:          "undef",
 		hbGens:             map[string]map[string]uint64{localNode: map[string]uint64{localNode: 0}},
+		hbPatchMsgUpdated:  make(map[string]time.Time),
 	}
 }
 

--- a/daemon/daemondata/hb_message.go
+++ b/daemon/daemondata/hb_message.go
@@ -64,8 +64,8 @@ func (d *data) getHbMessage() (hbtype.Msg, error) {
 			d.log.Error().Err(err).Msg("can't create delta for hb patch message")
 			return msg, err
 		}
-		d.subHbMode[d.localNode] = fmt.Sprintf("%d", len(msg.Deltas))
 		msg.Deltas = delta
+		d.subHbMode[d.localNode] = fmt.Sprintf("%d", len(msg.Deltas))
 		return msg, nil
 	case "full":
 		nodeData := d.pending.Cluster.Node[d.localNode]

--- a/daemon/daemondata/heartbeats.go
+++ b/daemon/daemondata/heartbeats.go
@@ -43,6 +43,7 @@ func (o opSetHeartbeatPing) call(ctx context.Context, d *data) {
 			delete(d.pending.Cluster.Node, peerNode)
 			delete(d.hbGens, peerNode)
 			delete(d.subHbMode, peerNode)
+			delete(d.hbPatchMsgUpdated, peerNode)
 		}
 		patch := make(jsondelta.Patch, 0)
 		op := jsondelta.Operation{

--- a/daemon/daemondata/heartbeats.go
+++ b/daemon/daemondata/heartbeats.go
@@ -41,6 +41,8 @@ func (o opSetHeartbeatPing) call(ctx context.Context, d *data) {
 		if _, ok := d.pending.Cluster.Node[peerNode]; ok {
 			d.log.Info().Msgf("evict from cluster node stale peer %s", peerNode)
 			delete(d.pending.Cluster.Node, peerNode)
+			delete(d.hbGens, peerNode)
+			delete(d.subHbMode, peerNode)
 		}
 		patch := make(jsondelta.Patch, 0)
 		op := jsondelta.Operation{

--- a/daemon/daemondata/sub_refresh.go
+++ b/daemon/daemondata/sub_refresh.go
@@ -1,0 +1,27 @@
+package daemondata
+
+import (
+	"context"
+)
+
+type (
+	opSubRefresh struct {
+		err chan<- error
+	}
+)
+
+// SubRefresh update sub...
+func SubRefresh(c chan<- any) error {
+	err := make(chan error)
+	op := opSubRefresh{
+		err: err,
+	}
+	c <- op
+	return <-err
+}
+
+func (o opSubRefresh) call(ctx context.Context, d *data) {
+	d.log.Debug().Msg("refresh daemon data sub...")
+	d.setSubHb()
+	o.err <- nil
+}

--- a/util/pubsub/main.go
+++ b/util/pubsub/main.go
@@ -328,16 +328,17 @@ func (b *Bus) onSubAddFilter(c cmdSubAddFilter) {
 }
 
 func (b *Bus) drain() {
-	b.log.Debug().Msg("draining")
-	defer b.log.Debug().Msg("drained")
+	b.log.Info().Msg("draining")
+	defer b.log.Info().Msg("drained")
 	i := 0
 	tC := time.After(100 * time.Millisecond)
 	for {
 		select {
-		case <-tC:
-			b.log.Debug().Msgf("drained dropped %d pending messages from the bus on stop", i)
 		case <-b.cmdC:
 			i += 1
+		case <-tC:
+			b.log.Info().Msgf("drained dropped %d pending messages from the bus on stop", i)
+			return
 		}
 	}
 }


### PR DESCRIPTION
This pull request fix possible daemon restart hangs because of not anymore processed commands from channels, after context is done

- daemondata:  hbRecvQ
- discover: svcaggCmdC 
- hb msgToTx: HBSendQ
- hb msgFromRx: HBRecvMsgQ
- callcount on its cmd channel

Another possible hang may occur during daemondata.queueNewHbMsg (write to drained chan from hb), so
now daemondata.queueNewHbMsg use ctx to abort when ctx is done
