### PR TITLE
Implement the resource restart

### DIFF
--- a/core/instance/monitor.go
+++ b/core/instance/monitor.go
@@ -225,6 +225,27 @@ func (t MonitorState) MarshalJSON() ([]byte, error) {
 	}
 }
 
+func (t *Monitor) UnmarshalJSON(b []byte) error {
+	type tempMonitor Monitor
+	var mon tempMonitor
+	if err := json.Unmarshal(b, &mon); err != nil {
+		return err
+	}
+	switch mon.GlobalExpect {
+	case MonitorGlobalExpectPlacedAt:
+		var options MonitorGlobalExpectOptionsPlacedAt
+		if b, err := json.Marshal(mon.GlobalExpectOptions); err != nil {
+			return err
+		} else if err := json.Unmarshal(b, &options); err != nil {
+			return err
+		} else {
+			mon.GlobalExpectOptions = options
+		}
+	}
+	*t = Monitor(mon)
+	return nil
+}
+
 func (t *MonitorState) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {

--- a/core/instance/monitor_test.go
+++ b/core/instance/monitor_test.go
@@ -19,24 +19,27 @@ func Test_Monitor_Unmarshal(t *testing.T) {
 
 		err = json.Unmarshal(b, &monitor)
 		require.Nil(t, err)
-		require.Equal(t, 1, monitor.Resources["fs#2"].RemainingRestarts)
+		require.Equal(t, 1, monitor.Resources["fs#1"].Restart.Remaining)
 
 		t0 := time.Time{}
 		expected := Monitor{
 			GlobalExpect:        MonitorGlobalExpectPlacedAt,
 			GlobalExpectUpdated: t0,
-			// TODO change to MonitorGlobalExpectOptionsPlacedAt ?
-			GlobalExpectOptions: map[string]interface{}{
-				"destination": []interface{}{"node1", "node2"}},
+			GlobalExpectOptions: MonitorGlobalExpectOptionsPlacedAt{
+				Destination: []string{"node1", "node2"},
+			},
 			IsLeader:           true,
 			IsHALeader:         false,
 			LocalExpect:        MonitorLocalExpectUnset,
 			LocalExpectUpdated: t0,
 			State:              MonitorStateIdle,
 			StateUpdated:       t0,
-			Resources: map[string]ResourceMonitor{
-				"fs#2": {
-					RemainingRestarts: 1, LastRestartAt: time.Date(2020, time.March, 4, 16, 33, 23, 167003830, time.UTC),
+			Resources: ResourceMonitorMap{
+				"fs#1": ResourceMonitor{
+					Restart: ResourceMonitorRestart{
+						Remaining: 1,
+						LastAt:    time.Date(2020, time.March, 4, 16, 33, 23, 167003830, time.UTC),
+					},
 				},
 			},
 		}
@@ -50,7 +53,7 @@ func Test_Monitor_Unmarshal(t *testing.T) {
 		require.Nil(t, err)
 		err = json.Unmarshal(b, &monitor)
 		require.Nil(t, err)
-		require.Equal(t, 1, monitor.Resources["fs#2"].RemainingRestarts)
+		require.Equal(t, 1, monitor.Resources["fs#1"].Restart.Remaining)
 	})
 }
 
@@ -58,9 +61,9 @@ func Test_Monitor_DeepCopy(t *testing.T) {
 	mon1 := Monitor{
 		LocalExpectUpdated:  time.Now(),
 		GlobalExpectUpdated: time.Now(),
-		Resources: map[string]ResourceMonitor{
-			"a": {1, time.Now()},
-			"b": {8, time.Now()},
+		Resources: ResourceMonitorMap{
+			"a": ResourceMonitor{Restart: ResourceMonitorRestart{Remaining: 1, LastAt: time.Now()}},
+			"b": ResourceMonitor{Restart: ResourceMonitorRestart{Remaining: 8, LastAt: time.Now()}},
 		},
 	}
 	mon2 := *mon1.DeepCopy()
@@ -72,15 +75,15 @@ func Test_Monitor_DeepCopy(t *testing.T) {
 	require.True(t, mon2.GlobalExpectUpdated.After(mon1.GlobalExpectUpdated))
 
 	if e, ok := mon2.Resources["a"]; ok {
-		e.LastRestartAt = time.Now()
-		e.RemainingRestarts++
+		e.Restart.LastAt = time.Now()
+		e.Restart.Remaining++
 		mon2.Resources["a"] = e
 	}
-	require.Equal(t, 1, mon1.Resources["a"].RemainingRestarts, "initial value changed!")
-	require.Equal(t, 8, mon1.Resources["b"].RemainingRestarts, "initial value changed!")
+	require.Equal(t, 1, mon1.Resources["a"].Restart.Remaining, "initial value changed!")
+	require.Equal(t, 8, mon1.Resources["b"].Restart.Remaining, "initial value changed!")
 
-	require.Equal(t, 2, mon2.Resources["a"].RemainingRestarts)
-	require.Equal(t, 8, mon2.Resources["b"].RemainingRestarts)
+	require.Equal(t, 2, mon2.Resources["a"].Restart.Remaining)
+	require.Equal(t, 8, mon2.Resources["b"].Restart.Remaining)
 
-	require.True(t, mon2.Resources["a"].LastRestartAt.After(mon1.Resources["a"].LastRestartAt))
+	require.True(t, mon2.Resources["a"].Restart.LastAt.After(mon1.Resources["a"].Restart.LastAt))
 }

--- a/core/instance/monitor_test.go
+++ b/core/instance/monitor_test.go
@@ -19,7 +19,7 @@ func Test_Monitor_Unmarshal(t *testing.T) {
 
 		err = json.Unmarshal(b, &monitor)
 		require.Nil(t, err)
-		require.Equal(t, 1, monitor.Restart["fs#2"].Retries)
+		require.Equal(t, 1, monitor.Resources["fs#2"].RemainingRestarts)
 
 		t0 := time.Time{}
 		expected := Monitor{
@@ -34,9 +34,9 @@ func Test_Monitor_Unmarshal(t *testing.T) {
 			LocalExpectUpdated: t0,
 			State:              MonitorStateIdle,
 			StateUpdated:       t0,
-			Restart: map[string]MonitorRestart{
+			Resources: map[string]ResourceMonitor{
 				"fs#2": {
-					Retries: 1, Updated: time.Date(2020, time.March, 4, 16, 33, 23, 167003830, time.UTC),
+					RemainingRestarts: 1, LastRestartAt: time.Date(2020, time.March, 4, 16, 33, 23, 167003830, time.UTC),
 				},
 			},
 		}
@@ -50,7 +50,7 @@ func Test_Monitor_Unmarshal(t *testing.T) {
 		require.Nil(t, err)
 		err = json.Unmarshal(b, &monitor)
 		require.Nil(t, err)
-		require.Equal(t, 1, monitor.Restart["fs#2"].Retries)
+		require.Equal(t, 1, monitor.Resources["fs#2"].RemainingRestarts)
 	})
 }
 
@@ -58,7 +58,7 @@ func Test_Monitor_DeepCopy(t *testing.T) {
 	mon1 := Monitor{
 		LocalExpectUpdated:  time.Now(),
 		GlobalExpectUpdated: time.Now(),
-		Restart: map[string]MonitorRestart{
+		Resources: map[string]ResourceMonitor{
 			"a": {1, time.Now()},
 			"b": {8, time.Now()},
 		},
@@ -71,16 +71,16 @@ func Test_Monitor_DeepCopy(t *testing.T) {
 	mon2.GlobalExpectUpdated = time.Now()
 	require.True(t, mon2.GlobalExpectUpdated.After(mon1.GlobalExpectUpdated))
 
-	if e, ok := mon2.Restart["a"]; ok {
-		e.Updated = time.Now()
-		e.Retries++
-		mon2.Restart["a"] = e
+	if e, ok := mon2.Resources["a"]; ok {
+		e.LastRestartAt = time.Now()
+		e.RemainingRestarts++
+		mon2.Resources["a"] = e
 	}
-	require.Equal(t, 1, mon1.Restart["a"].Retries, "initial value changed!")
-	require.Equal(t, 8, mon1.Restart["b"].Retries, "initial value changed!")
+	require.Equal(t, 1, mon1.Resources["a"].RemainingRestarts, "initial value changed!")
+	require.Equal(t, 8, mon1.Resources["b"].RemainingRestarts, "initial value changed!")
 
-	require.Equal(t, 2, mon2.Restart["a"].Retries)
-	require.Equal(t, 8, mon2.Restart["b"].Retries)
+	require.Equal(t, 2, mon2.Resources["a"].RemainingRestarts)
+	require.Equal(t, 8, mon2.Resources["b"].RemainingRestarts)
 
-	require.True(t, mon2.Restart["a"].Updated.After(mon1.Restart["a"].Updated))
+	require.True(t, mon2.Resources["a"].LastRestartAt.After(mon1.Resources["a"].LastRestartAt))
 }

--- a/core/instance/testdata/monitor.json
+++ b/core/instance/testdata/monitor.json
@@ -1,17 +1,24 @@
 {
   "global_expect": "placed@",
   "global_expect_updated": "0001-01-01T00:00:00Z",
-  "global_expect_options": {"destination":  ["node1", "node2"]},
+  "global_expect_options": {
+    "destination":  [
+      "node1",
+      "node2"
+    ]
+  },
   "is_leader": true,
   "is_ha_leader": false,
   "local_expect": "unset",
   "local_expect_updated": "0001-01-01T00:00:00Z",
   "state": "idle",
   "state_updated": "0001-01-01T00:00:00Z",
-  "restart": {
-    "fs#2": {
-      "retries": 1,
-      "updated": "2020-03-04T16:33:23.16700383Z"
+  "resources": {
+    "fs#1": {
+      "restart": {
+        "remaining": 1,
+        "last_at": "2020-03-04T16:33:23.16700383Z"
+      }
     }
   }
 }

--- a/core/instance/testdata/monitor_deprecated_restart.json
+++ b/core/instance/testdata/monitor_deprecated_restart.json
@@ -4,8 +4,13 @@
   "local_expect": "started",
   "local_expect_updated": "2020-03-04T16:33:23.16700383+01:00",
   "placement": "",
-  "restart": {
-    "fs#2": 1
+  "resources": {
+    "fs#1": {
+      "restart": {
+        "remaining": 1,
+        "last_at": "2020-03-04T16:33:23.16700383Z"
+      }
+    }
   },
   "status": "idle",
   "status_updated": 1619529551.5369837

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -278,11 +278,11 @@ func (t DisableFlag) FlagString() string {
 // FlagString returns a one character representation of the type instance.
 func (t RestartFlag) FlagString(retries int) string {
 	restart := int(t)
-	remaining := restart - retries
+	remaining := retries
 	switch {
 	case restart <= 0:
 		return "."
-	case remaining < 0:
+	case remaining <= 0:
 		return "0"
 	case remaining < 10:
 		return fmt.Sprintf("%d", remaining)

--- a/core/xconfig/main.go
+++ b/core/xconfig/main.go
@@ -380,8 +380,10 @@ func (t *T) GetBool(k key.T) bool {
 func (t *T) GetBoolStrict(k key.T) (bool, error) {
 	if v, err := t.Eval(k); err != nil {
 		return false, err
+	} else if i, ok := v.(bool); !ok {
+		return false, errors.Errorf("type error: expected int, got %v", v)
 	} else {
-		return v.(bool), nil
+		return i, nil
 	}
 }
 
@@ -393,8 +395,10 @@ func (t *T) GetDuration(k key.T) *time.Duration {
 func (t *T) GetDurationStrict(k key.T) (*time.Duration, error) {
 	if v, err := t.Eval(k); err != nil {
 		return nil, err
+	} else if i, ok := v.(*time.Duration); !ok {
+		return nil, errors.Errorf("type error: expected *time.Duration, got %v", v)
 	} else {
-		return v.(*time.Duration), nil
+		return i, nil
 	}
 }
 
@@ -406,8 +410,10 @@ func (t *T) GetInt(k key.T) int {
 func (t *T) GetIntStrict(k key.T) (int, error) {
 	if v, err := t.Eval(k); err != nil {
 		return 0, err
+	} else if i, ok := v.(int); !ok {
+		return 0, errors.Errorf("type error: expected int, got %v", v)
 	} else {
-		return v.(int), nil
+		return i, nil
 	}
 }
 

--- a/daemon/daemondata/main_test.go
+++ b/daemon/daemondata/main_test.go
@@ -81,7 +81,7 @@ func TestDaemonData(t *testing.T) {
 	remoteHost := "node2"
 
 	t.Run("from initialized", func(t *testing.T) {
-		t.Run("GetStatus return status with local status initialized", func(t *testing.T) {
+		t.Run("GetStatus return status with instance state initialized", func(t *testing.T) {
 			localNodeStatus := bus.GetNodeStatus(localNode)
 			require.NotNil(t, localNodeStatus)
 			require.Equalf(t, uint64(1), localNodeStatus.Gen[localNode],

--- a/daemon/daemondata/stats.go
+++ b/daemon/daemondata/stats.go
@@ -37,6 +37,7 @@ const (
 	idDropPeerNode
 	idGetHbMessage
 	idGetHbMessageType
+	idGetInstanceConfig
 	idGetInstanceStatus
 	idGetNodeData
 	idGetNodeMonitor

--- a/daemon/monitor/imon/crm_actions.go
+++ b/daemon/monitor/imon/crm_actions.go
@@ -2,6 +2,7 @@ package imon
 
 import (
 	"os"
+	"strings"
 
 	"opensvc.com/opensvc/core/env"
 	"opensvc.com/opensvc/core/instance"
@@ -51,6 +52,11 @@ func (o *imon) crmProvisionLeader() error {
 	return o.crmAction("provision leader", o.path.String(), "provision", "--local", "--leader", "--disable-rollback")
 }
 
+func (o *imon) crmResourceStart(rids []string) error {
+	s := strings.Join(rids, ",")
+	return o.crmAction("start", o.path.String(), "start", "--local", "--rid", s)
+}
+
 func (o *imon) crmStart() error {
 	return o.crmAction("start", o.path.String(), "start", "--local")
 }
@@ -88,7 +94,7 @@ func (o *imon) crmAction(title string, cmdArgs ...string) error {
 	)
 	if title != "" {
 		o.loggerWithState().Info().Msgf(
-			"crm action %s (local status:'%s') -> exec %s %s",
+			"crm action %s (instance state: %s) -> exec %s %s",
 			title, o.state.State, cmdPath, cmdArgs,
 		)
 	} else {
@@ -100,7 +106,7 @@ func (o *imon) crmAction(title string, cmdArgs ...string) error {
 	}
 	if title != "" {
 		o.loggerWithState().Info().Msgf(
-			"crm action %s (local status:'%s') <- exec %s %s",
+			"crm action %s (instance state: %s) <- exec %s %s",
 			title, o.state.State, cmdPath, cmdArgs,
 		)
 	} else {

--- a/daemon/monitor/imon/main.go
+++ b/daemon/monitor/imon/main.go
@@ -52,6 +52,7 @@ type (
 		pendingCancel context.CancelFunc
 
 		// updated data from object status update srcEvent
+		instConfig  instance.Config
 		instStatus  map[string]instance.Status
 		instMonitor map[string]instance.Monitor
 		nodeMonitor map[string]cluster.NodeMonitor
@@ -83,7 +84,7 @@ func Start(parent context.Context, p path.T, nodes []string) error {
 		LocalExpect:  instance.MonitorLocalExpectUnset,
 		GlobalExpect: instance.MonitorGlobalExpectUnset,
 		State:        instance.MonitorStateIdle,
-		Restart:      make(map[string]instance.MonitorRestart),
+		Resources:    make(map[string]instance.ResourceMonitor),
 		StateUpdated: time.Now(),
 	}
 	state := previousState
@@ -110,6 +111,8 @@ func Start(parent context.Context, p path.T, nodes []string) error {
 	o.nodeStatus = databus.GetNodeStatusMap()
 	o.nodeStats = databus.GetNodeStatsMap()
 	o.nodeMonitor = databus.GetNodeMonitorMap()
+	o.instConfig = databus.GetInstanceConfig(o.path, o.localhost)
+	o.initResourceMonitor()
 
 	go func() {
 		defer func() {

--- a/daemon/monitor/imon/main_cmd.go
+++ b/daemon/monitor/imon/main_cmd.go
@@ -44,6 +44,9 @@ func (o *imon) onInstanceStatusUpdated(srcNode string, srcCmd msgbus.InstanceSta
 			return
 		}
 		o.state.LocalExpect = instance.MonitorLocalExpectStarted
+
+		// reset the last monitor action execution time, to rearm the next monitor action
+		o.state.MonitorActionExecutedAt = time.Time{}
 		o.change = true
 
 	}

--- a/daemon/monitor/imon/main_cmd.go
+++ b/daemon/monitor/imon/main_cmd.go
@@ -43,6 +43,7 @@ func (o *imon) onInstanceStatusUpdated(srcNode string, srcCmd msgbus.InstanceSta
 		if o.state.LocalExpect == instance.MonitorLocalExpectStarted {
 			return
 		}
+		o.log.Info().Msgf("this instance is now considered started, resource restart and monitoring are enabled")
 		o.state.LocalExpect = instance.MonitorLocalExpectStarted
 
 		// reset the last monitor action execution time, to rearm the next monitor action
@@ -126,7 +127,7 @@ func (o *imon) onProgressInstanceMonitor(c msgbus.ProgressInstanceMonitor) {
 		default:
 			return
 		}
-		o.log.Info().Msgf("set local expect %s -> %s", o.state.LocalExpect, instance.MonitorLocalExpectUnset)
+		o.log.Info().Msgf("this instance is no longer considered started, resource restart and monitoring are disabled")
 		o.change = true
 		o.state.LocalExpect = instance.MonitorLocalExpectUnset
 	}

--- a/daemon/monitor/imon/orchestration.go
+++ b/daemon/monitor/imon/orchestration.go
@@ -28,6 +28,8 @@ func (o *imon) orchestrate() {
 		return
 	}
 
+	o.orchestrateResourceRestart()
+
 	switch o.state.GlobalExpect {
 	case instance.MonitorGlobalExpectUnset:
 		o.orchestrateUnset()

--- a/daemon/monitor/imon/orchestration_frozen.go
+++ b/daemon/monitor/imon/orchestration_frozen.go
@@ -4,7 +4,13 @@ import "opensvc.com/opensvc/core/instance"
 
 func (o *imon) orchestrateFrozen() {
 	switch o.state.State {
-	case instance.MonitorStateIdle:
+	case instance.MonitorStateIdle,
+		instance.MonitorStateStartFailed,
+		instance.MonitorStateStopFailed,
+		instance.MonitorStatePurgeFailed,
+		instance.MonitorStateProvisionFailed,
+		instance.MonitorStateUnprovisionFailed,
+		instance.MonitorStateReady:
 		o.frozenFromIdle()
 	}
 }
@@ -18,7 +24,7 @@ func (o *imon) frozenFromIdle() {
 
 func (o *imon) frozenClearIfReached() bool {
 	if o.instStatus[o.localhost].IsFrozen() {
-		o.log.Info().Msg("local status is frozen, unset global expect")
+		o.log.Info().Msg("instance state is frozen, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = instance.MonitorGlobalExpectUnset
 		o.state.LocalExpect = instance.MonitorLocalExpectUnset

--- a/daemon/monitor/imon/orchestration_provisioned.go
+++ b/daemon/monitor/imon/orchestration_provisioned.go
@@ -50,7 +50,7 @@ func (o *imon) provisionedFromWaitLeader() {
 
 func (o *imon) provisionedClearIfReached() bool {
 	if o.instStatus[o.localhost].Provisioned.IsOneOf(provisioned.True, provisioned.NotApplicable) {
-		o.log.Info().Msg("provisioned orchestration: local status provisioned, unset global expect")
+		o.log.Info().Msg("provisioned orchestration: instance state is provisioned, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = instance.MonitorGlobalExpectUnset
 		o.state.LocalExpect = instance.MonitorLocalExpectUnset

--- a/daemon/monitor/imon/orchestration_resource_restart.go
+++ b/daemon/monitor/imon/orchestration_resource_restart.go
@@ -1,0 +1,229 @@
+package imon
+
+import (
+	"time"
+
+	"opensvc.com/opensvc/core/cluster"
+	"opensvc.com/opensvc/core/instance"
+	"opensvc.com/opensvc/core/kind"
+	"opensvc.com/opensvc/core/provisioned"
+	"opensvc.com/opensvc/core/status"
+	"opensvc.com/opensvc/daemon/msgbus"
+	"opensvc.com/opensvc/util/hostname"
+	"opensvc.com/opensvc/util/pubsub"
+)
+
+type (
+	restartTodoMap map[string]bool
+)
+
+func (t restartTodoMap) Add(rid string) {
+	t[rid] = true
+}
+
+func (t restartTodoMap) Del(rid string) {
+	delete(t, rid)
+}
+
+func (t restartTodoMap) IsEmpty() bool {
+	return len(t) == 0
+}
+
+func newRestartTodoMap() restartTodoMap {
+	m := make(restartTodoMap)
+	return m
+}
+
+func (o *imon) orchestrateResourceRestart() {
+	todo := newRestartTodoMap()
+	pubMonitorAction := func(rid string) {
+		bus := pubsub.BusFromContext(o.ctx)
+		bus.Pub(msgbus.InstanceMonitorAction{
+			Path:   o.path,
+			Node:   hostname.Hostname(),
+			Action: o.instConfig.MonitorAction,
+			RID:    rid,
+		}, pubsub.Label{"path", o.path.String()}, pubsub.Label{"node", hostname.Hostname()})
+	}
+	doMonitorAction := func(rid string) {
+		if o.instConfig.MonitorAction != "" {
+			o.log.Info().Msgf("do %s monitor action", o.instConfig.MonitorAction)
+			pubMonitorAction(rid)
+		}
+		switch o.instConfig.MonitorAction {
+		case instance.MonitorActionCrash:
+		case instance.MonitorActionFreezeStop:
+			o.doFreezeStop()
+			o.doStop()
+		case instance.MonitorActionReboot:
+		case instance.MonitorActionSwitch:
+		}
+	}
+	resetTimer := func(rid string) {
+		todo.Del(rid)
+		if timer, ok := o.state.Resources.GetRestartTimer(rid); ok && timer != nil {
+			o.log.Info().Msgf("resource %s is up, reset delayed restart", rid)
+			timer.Stop()
+			o.state.Resources.SetRestartTimer(rid, nil)
+			o.change = true
+		}
+	}
+	resetRemaining := func(rid string) {
+		rcfg, ok := o.instConfig.Resources[rid]
+		if !ok {
+			return
+		}
+		if remaining, ok := o.state.Resources.GetRestartRemaining(rid); ok && remaining != rcfg.Restart {
+			o.log.Info().Msgf("resource %s is up, reset restart count to the max (%d -> %d)", rid, remaining, rcfg.Restart)
+			o.state.MonitorActionExecutedAt = time.Time{}
+			o.state.Resources.SetRestartRemaining(rid, rcfg.Restart)
+			o.change = true
+		}
+	}
+	resetRemainingAndTimer := func(rid string) {
+		resetRemaining(rid)
+		resetTimer(rid)
+	}
+	resetTimers := func() {
+		for _, res := range o.instStatus[o.localhost].Resources {
+			resetTimer(res.Rid)
+		}
+	}
+	planFor := func(rid string, resStatus status.T) {
+		rcfg, ok := o.instConfig.Resources[rid]
+		if !ok {
+			return
+		}
+		switch {
+		case rcfg.IsDisabled == true:
+			o.log.Debug().Msgf("resource %s restart skip: disable=%v", rid, rcfg.IsDisabled)
+			resetRemainingAndTimer(rid)
+		case resStatus.Is(status.NotApplicable, status.Undef):
+			o.log.Debug().Msgf("resource %s restart skip: status=%s", rid, resStatus)
+			resetRemainingAndTimer(rid)
+		case resStatus.Is(status.Up, status.StandbyUp):
+			o.log.Debug().Msgf("resource %s restart skip: status=%s", rid, resStatus)
+			resetRemainingAndTimer(rid)
+		case o.state.Resources.HasRestartTimer(rid):
+			o.log.Debug().Msgf("resource %s restart skip: already has a delay timer", rid)
+		default:
+			rmon := o.state.Resources[rid]
+			o.log.Info().Msgf("resource %s status %s, restart remaining %d out of %d", rid, resStatus, rmon.Restart.Remaining, rcfg.Restart)
+			if rmon.Restart.Remaining == 0 && o.state.MonitorActionExecutedAt.IsZero() {
+				o.state.MonitorActionExecutedAt = time.Now()
+				o.change = true
+				doMonitorAction(rid)
+			} else {
+				todo.Add(rid)
+			}
+		}
+	}
+	do := func() {
+		if todo.IsEmpty() {
+			return
+		}
+		rids := make([]string, 0)
+		now := time.Now()
+		var maxDelay time.Duration
+		for rid, _ := range todo {
+			rcfg := o.instConfig.Resources[rid]
+			rmon := o.state.Resources[rid]
+			if rcfg.RestartDelay != nil {
+				notBefore := rmon.Restart.LastAt.Add(*rcfg.RestartDelay)
+				if now.Before(notBefore) {
+					delay := notBefore.Sub(now)
+					if delay > maxDelay {
+						maxDelay = delay
+					}
+				}
+			}
+			rids = append(rids, rid)
+			o.state.Resources.DecRestartRemaining(rid)
+			o.change = true
+		}
+		timer := time.AfterFunc(maxDelay, func() {
+			now := time.Now()
+			for _, rid := range rids {
+				o.state.Resources.SetRestartLastAt(rid, now)
+				o.state.Resources.SetRestartTimer(rid, nil)
+				o.change = true
+			}
+			action := func() error {
+				return o.crmResourceStart(rids)
+			}
+			o.doTransitionAction(action, instance.MonitorStateStarting, instance.MonitorStateIdle, instance.MonitorStateStartFailed)
+		})
+		for _, rid := range rids {
+			o.state.Resources.SetRestartTimer(rid, timer)
+			o.change = true
+		}
+	}
+
+	// discard the cluster object
+	if o.path.String() == "cluster" {
+		return
+	}
+
+	// discard all execpt svc and vol
+	switch o.path.Kind {
+	case kind.Svc, kind.Vol:
+	default:
+		return
+	}
+
+	// discard if the instance status does not exist
+	if _, ok := o.instStatus[o.localhost]; !ok {
+		resetTimers()
+		return
+	}
+
+	// don't run on frozen nodes
+	if o.nodeStatus[o.localhost].IsFrozen() {
+		resetTimers()
+		return
+	}
+
+	// don't run when the node is not idle
+	if o.nodeMonitor[o.localhost].State != cluster.NodeMonitorStateIdle {
+		resetTimers()
+		return
+	}
+
+	// don't run on frozen instances
+	if o.instStatus[o.localhost].IsFrozen() {
+		resetTimers()
+		return
+	}
+
+	// discard not provisioned
+	if instanceStatus := o.instStatus[o.localhost]; instanceStatus.Provisioned.IsOneOf(provisioned.False, provisioned.Mixed, provisioned.Undef) {
+		o.log.Debug().Msgf("skip restart: provisioned=%s", instanceStatus.Provisioned)
+		resetTimers()
+		return
+	}
+
+	// discard if the instance is not idle,started
+	if instMonitor, ok := o.GetInstanceMonitor(o.localhost); !ok {
+		o.log.Debug().Msgf("skip restart: no instance monitor")
+		resetTimers()
+		return
+	} else {
+		switch instMonitor.State {
+		case instance.MonitorStateIdle, instance.MonitorStateStartFailed:
+			// pass
+		default:
+			o.log.Debug().Msgf("skip restart: state=%s", instMonitor.State)
+			return
+		}
+		if instMonitor.LocalExpect != instance.MonitorLocalExpectStarted {
+			o.log.Debug().Msgf("skip restart: local_expect=%s", instMonitor.LocalExpect)
+			resetTimers()
+			return
+		}
+	}
+
+	for _, res := range o.instStatus[o.localhost].Resources {
+		planFor(res.Rid, res.Status)
+	}
+	do()
+}

--- a/daemon/monitor/imon/orchestration_resource_restart.go
+++ b/daemon/monitor/imon/orchestration_resource_restart.go
@@ -11,6 +11,7 @@ import (
 	"opensvc.com/opensvc/daemon/msgbus"
 	"opensvc.com/opensvc/util/hostname"
 	"opensvc.com/opensvc/util/pubsub"
+	"opensvc.com/opensvc/util/toc"
 )
 
 type (
@@ -52,10 +53,16 @@ func (o *imon) orchestrateResourceRestart() {
 		}
 		switch o.instConfig.MonitorAction {
 		case instance.MonitorActionCrash:
+			if err := toc.Crash(); err != nil {
+				o.log.Error().Err(err).Msg("monitor action")
+			}
 		case instance.MonitorActionFreezeStop:
 			o.doFreezeStop()
 			o.doStop()
 		case instance.MonitorActionReboot:
+			if err := toc.Reboot(); err != nil {
+				o.log.Error().Err(err).Msg("monitor action")
+			}
 		case instance.MonitorActionSwitch:
 		}
 	}

--- a/daemon/monitor/imon/orchestration_stopped.go
+++ b/daemon/monitor/imon/orchestration_stopped.go
@@ -116,7 +116,7 @@ func (o *imon) stoppedFromAny() {
 
 func (o *imon) stoppedClearIfReached() bool {
 	if o.isLocalStopped() {
-		o.loggerWithState().Info().Msg("local status is stopped, unset global expect")
+		o.loggerWithState().Info().Msg("instance state is stopped, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = instance.MonitorGlobalExpectUnset
 		o.state.LocalExpect = instance.MonitorLocalExpectUnset

--- a/daemon/monitor/imon/orchestration_thawed.go
+++ b/daemon/monitor/imon/orchestration_thawed.go
@@ -6,7 +6,13 @@ import (
 
 func (o *imon) orchestrateThawed() {
 	switch o.state.State {
-	case instance.MonitorStateIdle:
+	case instance.MonitorStateIdle,
+		instance.MonitorStateStartFailed,
+		instance.MonitorStateStopFailed,
+		instance.MonitorStatePurgeFailed,
+		instance.MonitorStateProvisionFailed,
+		instance.MonitorStateUnprovisionFailed,
+		instance.MonitorStateReady:
 		o.ThawedFromIdle()
 	}
 }
@@ -20,7 +26,7 @@ func (o *imon) ThawedFromIdle() {
 
 func (o *imon) thawedClearIfReached() bool {
 	if o.instStatus[o.localhost].IsThawed() {
-		o.log.Info().Msg("local status is thawed, unset global expect")
+		o.log.Info().Msg("instance state is thawed, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = instance.MonitorGlobalExpectUnset
 		o.state.LocalExpect = instance.MonitorLocalExpectUnset

--- a/daemon/monitor/imon/orchestration_unprovisioned.go
+++ b/daemon/monitor/imon/orchestration_unprovisioned.go
@@ -65,7 +65,7 @@ func (o *imon) hasNonLeaderProvisioned() bool {
 
 func (o *imon) UnprovisionedClearIfReached() bool {
 	if o.instStatus[o.localhost].Provisioned.IsOneOf(provisioned.False, provisioned.NotApplicable) {
-		o.loggerWithState().Info().Msg("local status is not provisioned, unset global expect")
+		o.loggerWithState().Info().Msg("instance state is not provisioned, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = instance.MonitorGlobalExpectUnset
 		o.state.LocalExpect = instance.MonitorLocalExpectUnset

--- a/daemon/monitor/nmon/orchestration_frozen.go
+++ b/daemon/monitor/nmon/orchestration_frozen.go
@@ -28,7 +28,7 @@ func (o *nmon) frozenFromIdle() {
 
 func (o *nmon) frozenClearIfReached() bool {
 	if d := o.databus.GetNodeStatus(o.localhost); (d != nil) && !d.Frozen.IsZero() {
-		o.log.Info().Msg("local status is frozen, unset global expect")
+		o.log.Info().Msg("instance state is frozen, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = cluster.NodeMonitorGlobalExpectUnset
 		o.clearPending()

--- a/daemon/monitor/nmon/orchestration_thawed.go
+++ b/daemon/monitor/nmon/orchestration_thawed.go
@@ -29,7 +29,7 @@ func (o *nmon) ThawedFromIdle() {
 
 func (o *nmon) thawedClearIfReached() bool {
 	if d := o.databus.GetNodeStatus(o.localhost); (d != nil) && d.Frozen.IsZero() {
-		o.log.Info().Msg("local status is thawed, unset global expect")
+		o.log.Info().Msg("instance state is thawed, unset global expect")
 		o.change = true
 		o.state.GlobalExpect = cluster.NodeMonitorGlobalExpectUnset
 		o.clearPending()

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -37,6 +37,7 @@ var (
 		"HbPing":                  HbPing{},
 		"HbStale":                 HbStale{},
 		"HbStatusUpdated":         HbStatusUpdated{},
+		"InstanceMonitorAction":   InstanceMonitorAction{},
 		"InstanceMonitorDeleted":  InstanceMonitorDeleted{},
 		"InstanceMonitorUpdated":  InstanceMonitorUpdated{},
 		"InstanceStatusDeleted":   InstanceStatusDeleted{},
@@ -174,6 +175,13 @@ type (
 	HbStatusUpdated struct {
 		Node  string
 		Value cluster.HeartbeatThreadStatus
+	}
+
+	InstanceMonitorAction struct {
+		Path   path.T
+		Node   string
+		Action instance.MonitorAction
+		RID    string
 	}
 
 	InstanceMonitorDeleted struct {
@@ -394,6 +402,10 @@ func (e HbStale) Kind() string {
 
 func (e HbStatusUpdated) Kind() string {
 	return "HbStatusUpdated"
+}
+
+func (e InstanceMonitorAction) Kind() string {
+	return "InstanceMonitorAction"
 }
 
 func (e InstanceMonitorDeleted) Kind() string {

--- a/daemon/scheduler/main.go
+++ b/daemon/scheduler/main.go
@@ -343,7 +343,7 @@ func (t *T) scheduleNode() {
 
 func (t *T) scheduleObject(p path.T) {
 	if provisioned, ok := t.provisioned[p]; !ok {
-		t.log.Error().Msgf("schedule object %s: unknown provisioned state", p)
+		t.log.Debug().Msgf("schedule object %s: provisioned state has not been discovered yet", p)
 		return
 	} else if !provisioned {
 		t.log.Error().Msgf("schedule object %s: not provisioned", p)

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/mdlayher/netlink v1.4.2 // indirect
 	github.com/mdlayher/socket v0.0.0-20211102153432-57e3fa563ecb // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
+	github.com/mlafeldt/sysrq v0.0.0-20171106101645-38dd78d6e663 // indirect
 	github.com/opensvc/locker v1.0.3 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mlafeldt/sysrq v0.0.0-20171106101645-38dd78d6e663 h1:MHDwIOdJwjLVyhZCjGnu41UgZ+8BMGHdWXznGDT4ZXU=
+github.com/mlafeldt/sysrq v0.0.0-20171106101645-38dd78d6e663/go.mod h1:gYPk5ekH99d7k9AMQpJPOnXIFQXUTCYtoDe3zr3Nf5o=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/util/toc/bsd.go
+++ b/util/toc/bsd.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package toc
+
+import (
+	"opensvc.com/opensvc/util/command"
+)
+
+func Reboot() error {
+	cmd := command.New(
+		command.WithName("reboot"),
+		command.WithVarArgs("-q"),
+	)
+	return cmd.Run()
+}
+
+func Crash() error {
+	cmd := command.New(
+		command.WithName("halt"),
+		command.WithVarArgs("-q"),
+	)
+	return cmd.Run()
+}

--- a/util/toc/dummy.go
+++ b/util/toc/dummy.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package toc
+
+import (
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+func Reboot() error {
+	return errors.Errorf("toc action 'reboot' is not implemented on %s", runtime.GOOS)
+}
+
+func Crash() error {
+	return errors.Errorf("toc action 'crash' is not implemented on %s", runtime.GOOS)
+}

--- a/util/toc/linux.go
+++ b/util/toc/linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package toc
+
+import (
+	"github.com/mlafeldt/sysrq"
+)
+
+func Reboot() error {
+	return sysrq.Trigger(sysrq.Reboot)
+}
+
+func Crash() error {
+	return sysrq.Trigger(sysrq.Crash)
+}


### PR DESCRIPTION
* when a resource goes down on an instance with local_expect
  'started' try to restart it '<rid>.restart' times (default 0)
  with '<rid>.restart_delay' delay.

* if the resource has '<rid>.monitor=true' and not restartable
  after all retries, emit a InstanceMonitorAction event, and
  execute the 'DEFAULT.monitor_action'.

  example event:
	{
	  "kind": "InstanceMonitorAction",
	  "id": 1,
	  "t": "2023-01-12T17:47:53.001330232+01:00",
	  "data": {
	    "Path": "foo001",
	    "Node": "dev2n1",
	    "Action": "freeze_stop",
	    "RID": "fs#1"
	  }
	}

* if multiple resource are to be restarted, group them in a
  single CRM command, using the greatest restart_delay.

* available monitor actions:
  implemented:
       MonitorActionFreezeStop MonitorAction = "freeze_stop"
  to be implemented:
       MonitorActionCrash      MonitorAction = "crash"
       MonitorActionReboot     MonitorAction = "reboot"
       MonitorActionSwitch     MonitorAction = "switch"

* new keys in instance.Config:

	"config": {
	    "csum": "6609d24bb993f9e1a10832c6efddd8b3",
+	    "monitor_action": "freeze_stop",
	    "orchestrate": "ha",
	    "placement_policy": "nodes order",
	    "priority": 50,
+	    "resources": {
+		"fs#1": {
+		    "Restart": 4,
+		    "RestartDelay": 4000000000,
+		    "IsMonitored": false,
+		    "IsDisabled": false
+		},
+		"fs#2": {
+		    "Restart": 0,
+		    "RestartDelay": 500000000,
+		    "IsMonitored": false,
+		    "IsDisabled": false
+		}
+	    },
	    "scope": [
		"dev2n1",
		"dev2n2",
		"dev2n3"
	    ],
	    "topology": "failover",
	    "updated": "2023-01-12T12:59:18.007360891+01:00"
	},

* new keys in instance.Monitor:

  "monitor": {
      "global_expect": "unset",
      "global_expect_updated": "2023-01-12T14:42:41.446960288+01:00",
      "global_expect_options": null,
      "is_leader": true,
      "is_ha_leader": false,
      "local_expect": "started",
      "local_expect_updated": "2023-01-12T17:47:15.776674216+01:00",
      "session_id": "",
      "state": "idle",
      "state_updated": "2023-01-12T17:47:53.044128099+01:00",
+     "monitor_action_executed_at": "2023-01-12T17:47:52.990544636+01:00",
+     "resources": {
+         "fs#1": {
+             "restart": {
+                 "remaining": 0,
+                 "last_at": "2023-01-12T17:47:52.701101234+01:00"
+             }
+         },
+         "fs#2": {
+             "restart": {
+                 "remaining": 0,
+                 "last_at": "0001-01-01T00:00:00Z"
+             }
+         }
+     }
  },

* monitor.monitor_action_executed_at is reset to zero when remaining
  is reset to config.resources.<rid>.restart

* add a daemondata GetInstanceConfig(p path.T, node string) getter
