### PR TITLE
Add a secret private field to node.Config

### DIFF
--- a/core/cluster/cluster.go
+++ b/core/cluster/cluster.go
@@ -11,8 +11,8 @@ import (
 )
 
 type (
-	// Status describes the full Cluster state.
-	Status struct {
+	// Data describes the full Cluster state.
+	Data struct {
 		Cluster   Cluster               `json:"cluster"`
 		Collector CollectorThreadStatus `json:"collector"`
 		DNS       DNSThreadStatus       `json:"dns"`
@@ -23,25 +23,16 @@ type (
 	}
 
 	Cluster struct {
-		Config ClusterConfig            `json:"config"`
-		Status ClusterStatus            `json:"status"`
+		Config Config                   `json:"config"`
+		Status Status                   `json:"status"`
 		Object map[string]object.Status `json:"object"`
 
 		Node map[string]node.Node `json:"node"`
 	}
 
-	ClusterStatus struct {
+	Status struct {
 		Compat bool `json:"compat"`
 		Frozen bool `json:"frozen"`
-	}
-
-	// ClusterConfig describes the cluster id, name and nodes
-	// The cluster name is used as the right most part of cluster dns
-	// names.
-	ClusterConfig struct {
-		ID    string   `json:"id"`
-		Name  string   `json:"name"`
-		Nodes []string `json:"nodes"`
 	}
 
 	Sub struct {
@@ -64,12 +55,12 @@ type (
 	}
 )
 
-func (s *Status) DeepCopy() *Status {
+func (s *Data) DeepCopy() *Data {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return nil
 	}
-	newStatus := Status{}
+	newStatus := Data{}
 	if err := json.Unmarshal(b, &newStatus); err != nil {
 		return nil
 	}
@@ -77,7 +68,7 @@ func (s *Status) DeepCopy() *Status {
 }
 
 // WithSelector purges the dataset from objects not matching the selector expression
-func (s *Status) WithSelector(selector string) *Status {
+func (s *Data) WithSelector(selector string) *Data {
 	if selector == "" {
 		return s
 	}
@@ -105,7 +96,7 @@ func (s *Status) WithSelector(selector string) *Status {
 }
 
 // WithNamespace purges the dataset from objects not matching the namespace
-func (s *Status) WithNamespace(namespace string) *Status {
+func (s *Data) WithNamespace(namespace string) *Data {
 	if namespace == "" {
 		return s
 	}
@@ -128,7 +119,7 @@ func (s *Status) WithNamespace(namespace string) *Status {
 
 // GetNodeData extracts from the cluster dataset all information relative
 // to node data.
-func (s *Status) GetNodeData(nodename string) *node.Node {
+func (s *Data) GetNodeData(nodename string) *node.Node {
 	if nodeData, ok := s.Cluster.Node[nodename]; ok {
 		return &nodeData
 	}
@@ -137,7 +128,7 @@ func (s *Status) GetNodeData(nodename string) *node.Node {
 
 // GetNodeStatus extracts from the cluster dataset all information relative
 // to node status.
-func (s *Status) GetNodeStatus(nodename string) *node.Status {
+func (s *Data) GetNodeStatus(nodename string) *node.Status {
 	if nodeData, ok := s.Cluster.Node[nodename]; ok {
 		return &nodeData.Status
 	}
@@ -146,7 +137,7 @@ func (s *Status) GetNodeStatus(nodename string) *node.Status {
 
 // GetObjectStatus extracts from the cluster dataset all information relative
 // to an object.
-func (s *Status) GetObjectStatus(p path.T) object.Digest {
+func (s *Data) GetObjectStatus(p path.T) object.Digest {
 	ps := p.String()
 	data := object.NewStatus()
 	data.Path = p

--- a/core/cluster/cluster_test.go
+++ b/core/cluster/cluster_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStatusUnmarshalJSON(t *testing.T) {
-	var clusterStatus Status
+	var clusterStatus Data
 	path := filepath.Join("test-fixtures", "clusterStatus.json")
 	b, err := os.ReadFile(path)
 	assert.Nil(t, err)

--- a/core/cluster/config.go
+++ b/core/cluster/config.go
@@ -1,0 +1,25 @@
+package cluster
+
+type (
+	// Config describes the cluster id, name and nodes
+	// The cluster name is used as the right most part of cluster dns
+	// names.
+	Config struct {
+		ID    string   `json:"id"`
+		Name  string   `json:"name"`
+		Nodes []string `json:"nodes"`
+		DNS   []string `json:"dns"`
+
+		// fields private, no exposed in daemon data
+		// json nor events
+		secret string
+	}
+)
+
+func (t Config) Secret() string {
+	return t.secret
+}
+
+func (t *Config) SetSecret(s string) {
+	t.secret = s
+}

--- a/core/cluster/frame.go
+++ b/core/cluster/frame.go
@@ -56,8 +56,8 @@ type (
 	Frame struct {
 		Nodes    []string
 		Sections []string
-		Current  Status
-		Previous Status
+		Current  Data
+		Previous Data
 		Stats    Stats
 
 		// private

--- a/core/clusterip/main.go
+++ b/core/clusterip/main.go
@@ -79,7 +79,7 @@ func (t T) LoadTreeNode(head *tree.Node) {
 	head.AddColumn().AddText("")
 }
 
-func (t L) Load(clusterStatus cluster.Status) L {
+func (t L) Load(clusterStatus cluster.Data) L {
 	l := NewL()
 	for nodename, nodeData := range clusterStatus.Cluster.Node {
 		for ps, inst := range nodeData.Instance {

--- a/core/commands/object_print_status.go
+++ b/core/commands/object_print_status.go
@@ -104,7 +104,7 @@ func (t *CmdObjectPrintStatus) extractFromDaemon(selector string, c *client.T) (
 	var (
 		err           error
 		b             []byte
-		clusterStatus cluster.Status
+		clusterStatus cluster.Data
 	)
 	b, err = c.NewGetDaemonStatus().
 		SetSelector(selector).

--- a/core/monitor/main.go
+++ b/core/monitor/main.go
@@ -109,7 +109,7 @@ func (m *T) Do(getter Getter, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	var data cluster.Status
+	var data cluster.Data
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (m *T) Do(getter Getter, out io.Writer) error {
 	return nil
 }
 
-func (m *T) doOneShot(data cluster.Status, clear bool, out io.Writer) {
+func (m *T) doOneShot(data cluster.Data, clear bool, out io.Writer) {
 	human := func() string {
 		f := cluster.Frame{
 			Current:  data,
@@ -145,13 +145,13 @@ func (m *T) DoWatch(statusGetter Getter, evReader event.ReadCloser, out io.Write
 	return m.watch(statusGetter, evReader, out)
 }
 
-func patchedStatus(b []byte, p jsondelta.Patch) ([]byte, *cluster.Status, error) {
+func patchedStatus(b []byte, p jsondelta.Patch) ([]byte, *cluster.Data, error) {
 	newB, err := p.Apply(b)
 	if err != nil {
 		//_, _ = fmt.Fprintf(os.Stderr, "patches.Apply failure: %s, patch len: %d, patch:%+v\n", err, len(p), p)
 		return nil, nil, err
 	}
-	data := cluster.Status{}
+	data := cluster.Data{}
 	if err := json.Unmarshal(newB, &data); err != nil {
 		return nil, nil, err
 	}
@@ -161,12 +161,12 @@ func patchedStatus(b []byte, p jsondelta.Patch) ([]byte, *cluster.Status, error)
 func (m *T) watch(statusGetter Getter, evReader event.ReadCloser, out io.Writer) error {
 	var (
 		b    []byte
-		data *cluster.Status
+		data *cluster.Data
 		err  error
 
 		errC   = make(chan error)
 		eventC = make(chan *event.Event, 100)
-		dataC  = make(chan *cluster.Status)
+		dataC  = make(chan *cluster.Data)
 
 		patchById = make(map[uint64][]jsondelta.Operation)
 		nextId    uint64
@@ -203,7 +203,7 @@ func (m *T) watch(statusGetter Getter, evReader event.ReadCloser, out io.Writer)
 	}
 
 	wg.Add(1)
-	go func(d *cluster.Status) {
+	go func(d *cluster.Data) {
 		defer wg.Done()
 		m.doOneShot(*d, true, out)
 		// show data when new data published on dataC

--- a/core/network/main.go
+++ b/core/network/main.go
@@ -293,7 +293,6 @@ func (t T) IPNet() (*net.IPNet, error) {
 	return ipnet, err
 }
 
-//
 // NodeSubnet returns the network subnet assigned to a cluster node, as a *net.IPNet.
 // This subnet is usually found in the network configuration, as a subnet@<nodename>
 // option. If not found there, allocate and write one.
@@ -305,14 +304,16 @@ func (t T) IPNet() (*net.IPNet, error) {
 //
 // Example:
 // With
-//    cluster.nodes = n1 n2 n3
-//    net1.network = 10.0.0.0/24
-//    net1.ips_per_node = 64
-// =>
-//    subnet@n1 = 10.0.0.0/26
-//    subnet@n2 = 10.0.0.64/26
-//    subnet@n3 = 10.0.0.128/26
 //
+//	cluster.nodes = n1 n2 n3
+//	net1.network = 10.0.0.0/24
+//	net1.ips_per_node = 64
+//
+// =>
+//
+//	subnet@n1 = 10.0.0.0/26
+//	subnet@n2 = 10.0.0.64/26
+//	subnet@n3 = 10.0.0.128/26
 func (t *T) NodeSubnet(nodename string) (*net.IPNet, error) {
 	if nodename == "" {
 		return nil, fmt.Errorf("empty nodename")
@@ -372,7 +373,7 @@ func getClusterIPList(c *client.T, selector string) (clusterip.L, error) {
 	var (
 		err           error
 		b             []byte
-		clusterStatus cluster.Status
+		clusterStatus cluster.Data
 	)
 	b, err = c.NewGetDaemonStatus().
 		SetSelector(selector).

--- a/core/node/config.go
+++ b/core/node/config.go
@@ -7,10 +7,6 @@ type (
 		MaintenanceGracePeriod time.Duration `json:"maintenance_grace_period"`
 		ReadyPeriod            time.Duration `json:"ready_period"`
 		RejoinGracePeriod      time.Duration `json:"rejoin_grace_period"`
-
-		// fields private, no exposed in daemon data
-		// json nor events
-		secret string
 	}
 )
 
@@ -18,11 +14,4 @@ func (t *Config) DeepCopy() *Config {
 	var data Config = *t
 	return &data
 
-}
-
-func (t Config) Secret() string {
-	return t.secret
-}
-func (t *Config) SetSecret(s string) {
-	t.secret = s
 }

--- a/core/node/config.go
+++ b/core/node/config.go
@@ -4,9 +4,13 @@ import "time"
 
 type (
 	Config struct {
-		MaintenanceGracePeriod time.Duration
-		ReadyPeriod            time.Duration
-		RejoinGracePeriod      time.Duration
+		MaintenanceGracePeriod time.Duration `json:"maintenance_grace_period"`
+		ReadyPeriod            time.Duration `json:"ready_period"`
+		RejoinGracePeriod      time.Duration `json:"rejoin_grace_period"`
+
+		// fields private, no exposed in daemon data
+		// json nor events
+		secret string
 	}
 )
 
@@ -14,4 +18,11 @@ func (t *Config) DeepCopy() *Config {
 	var data Config = *t
 	return &data
 
+}
+
+func (t Config) Secret() string {
+	return t.secret
+}
+func (t *Config) SetSecret(s string) {
+	t.secret = s
 }

--- a/daemon/daemonapi/get_daemon_events_test.go
+++ b/daemon/daemonapi/get_daemon_events_test.go
@@ -24,14 +24,14 @@ func TestGetDaemonEventsParams(t *testing.T) {
 			},
 		},
 		"types and labels": {
-			filterS: []string{"ObjectStatusUpdated,path=root/svc/foo", "CfgFileRemoved,path=root/svc/bar"},
+			filterS: []string{"ObjectStatusUpdated,path=root/svc/foo", "ConfigFileRemoved,path=root/svc/bar"},
 			expected: []Filter{
 				{
 					Kind:   msgbus.ObjectStatusUpdated{},
 					Labels: []pubsub.Label{{"path", "root/svc/foo"}},
 				},
 				{
-					Kind:   msgbus.CfgFileRemoved{},
+					Kind:   msgbus.ConfigFileRemoved{},
 					Labels: []pubsub.Label{{"path", "root/svc/bar"}},
 				},
 			},

--- a/daemon/daemondata/cluster_config.go
+++ b/daemon/daemondata/cluster_config.go
@@ -1,0 +1,55 @@
+package daemondata
+
+import (
+	"context"
+
+	"opensvc.com/opensvc/core/cluster"
+	"opensvc.com/opensvc/daemon/msgbus"
+	"opensvc.com/opensvc/util/jsondelta"
+)
+
+type (
+	opSetClusterConfig struct {
+		err   chan<- error
+		value cluster.Config
+	}
+)
+
+// SetClusterConfig sets Monitor.Cluster.Config
+func (t T) SetClusterConfig(value cluster.Config) error {
+	err := make(chan error)
+	op := opSetClusterConfig{
+		err:   err,
+		value: value,
+	}
+	t.cmdC <- op
+	return <-err
+}
+
+func (o opSetClusterConfig) call(ctx context.Context, d *data) {
+	d.counterCmd <- idSetClusterConfig
+	/*
+		// TODO: do we need a Equal() ?
+		if d.pending.Cluster.Config == o.value {
+			o.err <- nil
+			return
+		}
+	*/
+	d.pending.Cluster.Config = o.value
+	op := jsondelta.Operation{
+		OpPath:  jsondelta.OperationPath{"cluster", "config"},
+		OpValue: jsondelta.NewOptValue(o.value),
+		OpKind:  "replace",
+	}
+	d.pendingOps = append(d.pendingOps, op)
+	d.bus.Pub(
+		msgbus.ClusterConfigUpdated{
+			Node:  d.localNode,
+			Value: o.value,
+		},
+	)
+	select {
+	case <-ctx.Done():
+	case o.err <- nil:
+	}
+}

--- a/daemon/daemondata/cluster_status.go
+++ b/daemon/daemondata/cluster_status.go
@@ -7,8 +7,8 @@ import (
 )
 
 // GetStatus returns deep copy of status
-func (t T) GetStatus() *cluster.Status {
-	status := make(chan *cluster.Status)
+func (t T) GetStatus() *cluster.Data {
+	status := make(chan *cluster.Data)
 	t.cmdC <- opGetStatus{
 		status: status,
 	}
@@ -16,7 +16,7 @@ func (t T) GetStatus() *cluster.Status {
 }
 
 type opGetStatus struct {
-	status chan<- *cluster.Status
+	status chan<- *cluster.Data
 }
 
 func (o opGetStatus) call(ctx context.Context, d *data) {

--- a/daemon/daemondata/data.go
+++ b/daemon/daemondata/data.go
@@ -32,7 +32,7 @@ type (
 		previousRemoteInfo map[string]remoteInfo
 
 		// pending is the live current data (after apply patch, commit local pendingOps)
-		pending *cluster.Status
+		pending *cluster.Data
 
 		pendingOps    []jsondelta.Operation // local data pending operations not yet in patchQueue
 		patchQueue    patchQueue            // local data patch queue for remotes

--- a/daemon/daemondata/data_init.go
+++ b/daemon/daemondata/data_init.go
@@ -2,7 +2,6 @@ package daemondata
 
 import (
 	"path/filepath"
-	"strings"
 	"time"
 
 	"opensvc.com/opensvc/core/cluster"
@@ -19,14 +18,9 @@ import (
 func newData(counterCmd chan<- interface{}) *data {
 	localNode := hostname.Hostname()
 	nodeData := newNodeData(localNode)
-	status := cluster.Status{
+	status := cluster.Data{
 		Cluster: cluster.Cluster{
-			Config: cluster.ClusterConfig{
-				ID:    rawconfig.ClusterSection().ID,
-				Name:  rawconfig.ClusterSection().Name,
-				Nodes: strings.Fields(rawconfig.ClusterSection().Nodes),
-			},
-			Status: cluster.ClusterStatus{
+			Status: cluster.Status{
 				Compat: false,
 				Frozen: true,
 			},

--- a/daemon/daemondata/main_test.go
+++ b/daemon/daemondata/main_test.go
@@ -87,8 +87,8 @@ func TestDaemonData(t *testing.T) {
 			require.Equalf(t, uint64(1), localNodeStatus.Gen[localNode],
 				"expected local node gen 1, got %+v", localNodeStatus)
 			cluster := bus.GetStatus().Cluster
-			require.Equal(t, "cluster1", cluster.Config.Name)
-			require.Equalf(t, "d0cdc684-b235-11eb-b929-acde48001122", cluster.Config.ID,
+			require.Equal(t, "", cluster.Config.Name)
+			require.Equalf(t, "", cluster.Config.ID,
 				"got %+v", cluster)
 		})
 		require.False(t, t.Failed()) // fail on first error
@@ -214,9 +214,9 @@ func TestDaemonData(t *testing.T) {
 			cluster := bus.GetStatus().Cluster
 
 			// cluster.node.<node>.config
-			require.Equal(t, "cluster1", cluster.Config.Name)
+			require.Equal(t, "", cluster.Config.Name)
 			// TODO ensure expected cluster id from test cluster.conf file
-			require.Equal(t, "d0cdc684-b235-11eb-b929-acde48001122", cluster.Config.ID)
+			require.Equal(t, "", cluster.Config.ID)
 			//require.Equal(t, []string{"node1", "node2"}, cluster.Config.Nodes)
 
 			// cluster.node.<node>.status

--- a/daemon/daemondata/node_config.go
+++ b/daemon/daemondata/node_config.go
@@ -1,0 +1,55 @@
+package daemondata
+
+import (
+	"context"
+
+	"opensvc.com/opensvc/core/node"
+	"opensvc.com/opensvc/daemon/msgbus"
+	"opensvc.com/opensvc/util/jsondelta"
+)
+
+type (
+	opSetNodeConfig struct {
+		err   chan<- error
+		value node.Config
+	}
+)
+
+// SetNodeConfig sets Monitor.Node.<localhost>.Config
+func (t T) SetNodeConfig(value node.Config) error {
+	err := make(chan error)
+	op := opSetNodeConfig{
+		err:   err,
+		value: value,
+	}
+	t.cmdC <- op
+	return <-err
+}
+
+func (o opSetNodeConfig) call(ctx context.Context, d *data) {
+	d.counterCmd <- idSetNodeConfig
+	v := d.pending.Cluster.Node[d.localNode]
+	if v.Config == o.value {
+		o.err <- nil
+		return
+	}
+	v.Config = o.value
+	d.pending.Cluster.Node[d.localNode] = v
+	op := jsondelta.Operation{
+		OpPath:  jsondelta.OperationPath{"config"},
+		OpValue: jsondelta.NewOptValue(o.value),
+		OpKind:  "replace",
+	}
+	d.pendingOps = append(d.pendingOps, op)
+	d.bus.Pub(
+		msgbus.NodeConfigUpdated{
+			Node:  d.localNode,
+			Value: o.value,
+		},
+		labelLocalNode,
+	)
+	select {
+	case <-ctx.Done():
+	case o.err <- nil:
+	}
+}

--- a/daemon/daemondata/stats.go
+++ b/daemon/daemondata/stats.go
@@ -29,6 +29,7 @@ const (
 	idApplyFull
 	idApplyPatch
 	idCommitPending
+	idClusterConfigUpdated
 	idDelInstanceConfig
 	idDelInstanceStatus
 	idDelObjectStatus
@@ -49,7 +50,7 @@ const (
 	idGetServiceNames
 	idGetStatus
 	idSetHeartbeatPing
-	idSetSubHb
+	idSetClusterConfig
 	idSetInstanceConfig
 	idSetInstanceFrozen
 	idSetInstanceMonitor
@@ -59,40 +60,43 @@ const (
 	idSetNodeOsPaths
 	idSetNodeStats
 	idSetObjectStatus
+	idSetSubHb
 	idStats
 )
 
 var (
 	idToName = map[int]string{
-		idUndef:              "undef",
-		idApplyFull:          "apply-full",
-		idApplyPatch:         "apply-patch",
-		idCommitPending:      "commit-pending",
-		idDelInstanceConfig:  "del-instance-config",
-		idDelInstanceStatus:  "del-instance-status",
-		idDelObjectStatus:    "del-object-status",
-		idDelNodeMonitor:     "del-node-monitor",
-		idDelInstanceMonitor: "del-intance-monitor",
-		idDropPeerNode:       "drop-peer-node",
-		idGetHbMessage:       "get-hb-message",
-		idGetHbMessageType:   "get-hb-message-type",
-		idGetInstanceStatus:  "get-instance-status",
-		idGetNode:            "get-node",
-		idGetNodeStatus:      "get-node-status",
-		idGetNodeStatusMap:   "get-node-status-map",
-		idGetNodesInfo:       "get-nodes-info",
-		idGetServiceNames:    "get-service-names",
-		idGetStatus:          "get-status",
-		idSetSubHb:           "set-sub-hb",
-		idSetObjectStatus:    "set-object-status",
-		idSetInstanceConfig:  "set-instance-config",
-		idSetInstanceFrozen:  "set-instance-frozen",
-		idSetInstanceStatus:  "set-instance-status",
-		idSetNodeConfig:      "set-node-config",
-		idSetNodeMonitor:     "set-node-monitor",
-		idSetNodeOsPaths:     "set-node-os-paths",
-		idSetNodeStats:       "set-node-stats",
-		idSetInstanceMonitor: "set-instance-monitor",
-		idStats:              "stats",
+		idUndef:                "undef",
+		idApplyFull:            "apply-full",
+		idApplyPatch:           "apply-patch",
+		idCommitPending:        "commit-pending",
+		idClusterConfigUpdated: "cluster-config-updated",
+		idDelInstanceConfig:    "del-instance-config",
+		idDelInstanceStatus:    "del-instance-status",
+		idDelObjectStatus:      "del-object-status",
+		idDelNodeMonitor:       "del-node-monitor",
+		idDelInstanceMonitor:   "del-intance-monitor",
+		idDropPeerNode:         "drop-peer-node",
+		idGetHbMessage:         "get-hb-message",
+		idGetHbMessageType:     "get-hb-message-type",
+		idGetInstanceStatus:    "get-instance-status",
+		idGetNode:              "get-node",
+		idGetNodeStatus:        "get-node-status",
+		idGetNodeStatusMap:     "get-node-status-map",
+		idGetNodesInfo:         "get-nodes-info",
+		idGetServiceNames:      "get-service-names",
+		idGetStatus:            "get-status",
+		idSetClusterConfig:     "set-cluster-config",
+		idSetObjectStatus:      "set-object-status",
+		idSetInstanceConfig:    "set-instance-config",
+		idSetInstanceFrozen:    "set-instance-frozen",
+		idSetInstanceMonitor:   "set-instance-monitor",
+		idSetInstanceStatus:    "set-instance-status",
+		idSetNodeConfig:        "set-node-config",
+		idSetNodeMonitor:       "set-node-monitor",
+		idSetNodeOsPaths:       "set-node-os-paths",
+		idSetNodeStats:         "set-node-stats",
+		idSetSubHb:             "set-sub-hb",
+		idStats:                "stats",
 	}
 )

--- a/daemon/monitor/instcfg/main.go
+++ b/daemon/monitor/instcfg/main.go
@@ -125,7 +125,7 @@ func (o *T) startSubscriptions(ctx context.Context) {
 	o.sub = bus.Sub(o.path.String() + " instcfg")
 	o.sub.AddFilter(msgbus.ConfigFileRemoved{}, label)
 	o.sub.AddFilter(msgbus.ConfigFileUpdated{}, label, nodeLabel)
-	if last := o.sub.AddFilterGetLast(msgbus.ClusterConfigUpdated{}, nodeLabel); last != nil {
+	if last := o.sub.AddFilterGetLast(msgbus.ClusterConfigUpdated{}); last != nil {
 		o.onClusterConfigUpdated(last.(msgbus.ClusterConfigUpdated))
 	}
 	if o.path.String() != clusterId {

--- a/daemon/monitor/nmon/main.go
+++ b/daemon/monitor/nmon/main.go
@@ -30,9 +30,11 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"opensvc.com/opensvc/core/kind"
 	"opensvc.com/opensvc/core/node"
 	"opensvc.com/opensvc/core/nodesinfo"
 	"opensvc.com/opensvc/core/object"
+	"opensvc.com/opensvc/core/path"
 	"opensvc.com/opensvc/core/rawconfig"
 	"opensvc.com/opensvc/core/xconfig"
 	"opensvc.com/opensvc/daemon/daemondata"
@@ -47,6 +49,7 @@ import (
 type (
 	nmon struct {
 		config        *xconfig.T
+		clusterConfig *xconfig.T
 		state         node.Monitor
 		previousState node.Monitor
 
@@ -99,6 +102,12 @@ func Start(parent context.Context) error {
 		return err
 	} else {
 		o.config = n.MergedConfig()
+	}
+
+	if n, err := object.NewCcfg(path.T{Kind: kind.Ccfg, Name: "cluster"}); err != nil {
+		return err
+	} else {
+		o.clusterConfig = n.Config()
 	}
 
 	o.startSubscriptions()

--- a/daemon/monitor/nmon/main_cmd.go
+++ b/daemon/monitor/nmon/main_cmd.go
@@ -31,6 +31,7 @@ func (o *nmon) pubNodeConfig() {
 
 func (o *nmon) getNodeConfig() node.Config {
 	var (
+		keyClusterSecret          = key.New("cluster", "secret")
 		keyMaintenanceGracePeriod = key.New("node", "maintenance_grace_period")
 		keyReadyPeriod            = key.New("node", "ready_period")
 		keyRejoinGracePeriod      = key.New("node", "rejoin_grace_period")
@@ -44,6 +45,9 @@ func (o *nmon) getNodeConfig() node.Config {
 	}
 	if d := o.config.GetDuration(keyRejoinGracePeriod); d != nil {
 		cfg.RejoinGracePeriod = *d
+	}
+	if s := o.config.GetString(keyClusterSecret); s != "" {
+		cfg.SetSecret(s)
 	}
 	return cfg
 }

--- a/daemon/msgbus/messages.go
+++ b/daemon/msgbus/messages.go
@@ -20,6 +20,7 @@ import (
 var (
 	kindToT = map[string]any{
 		"ApiClient":                 ApiClient{},
+		"ClusterConfigUpdated":      ClusterConfigUpdated{},
 		"ConfigDeleted":             ConfigDeleted{},
 		"ConfigFileRemoved":         ConfigFileRemoved{},
 		"ConfigFileUpdated":         ConfigFileUpdated{},
@@ -107,6 +108,11 @@ type (
 
 	ClientUnSub struct {
 		ApiClient
+	}
+
+	ClusterConfigUpdated struct {
+		Node  string
+		Value cluster.Config
 	}
 
 	// DataUpdated is a patch of changed data
@@ -315,6 +321,10 @@ func DropPendingMsg(c <-chan any, duration time.Duration) {
 
 func (e ApiClient) String() string {
 	return fmt.Sprintf("%s %s", e.Name, e.Time)
+}
+
+func (e ClusterConfigUpdated) Kind() string {
+	return "ClusterConfigUpdated"
 }
 
 func (e ConfigDeleted) Kind() string {

--- a/util/pubsub/main.go
+++ b/util/pubsub/main.go
@@ -263,6 +263,8 @@ func (b *Bus) Start(ctx context.Context) {
 			case cmd := <-b.cmdC:
 				beginCmd <- cmd
 				switch c := cmd.(type) {
+				case cmdGetLast:
+					b.onGetLastCmd(c)
 				case cmdPub:
 					b.onPubCmd(c)
 				case cmdSubAddFilter:


### PR DESCRIPTION
Not exposed in daemon status nor events streamed by the api, but available to the internal NodeConfigUpdated subscribers.

All users of rawconfig.LoadSections().Secret can not use this as a replacement.