### PR TITLE
dev

### DIFF
--- a/core/network/main.go
+++ b/core/network/main.go
@@ -206,6 +206,11 @@ func (t T) key(option string) key.T {
 	return key.New("network#"+t.name, option)
 }
 
+func (t *T) GetInt(s string) int {
+	k := t.key(s)
+	return t.Config().GetInt(k)
+}
+
 func (t *T) GetString(s string) string {
 	k := t.key(s)
 	return t.Config().GetString(k)

--- a/core/network/route.go
+++ b/core/network/route.go
@@ -5,6 +5,7 @@ package network
 import (
 	"net"
 
+	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 
 	"opensvc.com/opensvc/util/rttables"
@@ -57,13 +58,15 @@ func (t Route) Add() error {
 		Src: t.Src,
 		Gw:  t.Gateway,
 	}
-	if intf, err := net.InterfaceByName(t.Dev); err != nil {
-		return err
-	} else {
-		nlRoute.LinkIndex = intf.Index
+	if t.Dev != "" {
+		if intf, err := net.InterfaceByName(t.Dev); err != nil {
+			return errors.Wrapf(err, "interface lookup '%s'", t.Dev)
+		} else {
+			nlRoute.LinkIndex = intf.Index
+		}
 	}
 	if i, err := rttables.Index(t.Table); err != nil {
-		return err
+		return errors.Wrapf(err, "table lookup '%s'", t.Table)
 	} else {
 		nlRoute.Table = i
 	}

--- a/core/network/setup.go
+++ b/core/network/setup.go
@@ -98,11 +98,11 @@ func setupNetwork(n *object.Node, nw Networker, dir string) error {
 		nw.Log().Info().Msgf("network setup: skip invalid network")
 		return nil
 	}
-	if err := setupNetworkCNI(n, dir, nw); err != nil {
-		return err
-	}
 	if i, ok := nw.(Setuper); ok {
 		return i.Setup()
+	}
+	if err := setupNetworkCNI(n, dir, nw); err != nil {
+		return err
 	}
 	return nil
 }

--- a/core/network/setup.go
+++ b/core/network/setup.go
@@ -99,7 +99,9 @@ func setupNetwork(n *object.Node, nw Networker, dir string) error {
 		return nil
 	}
 	if i, ok := nw.(Setuper); ok {
-		return i.Setup()
+		if err := i.Setup(); err != nil {
+			return err
+		}
 	}
 	if err := setupNetworkCNI(n, dir, nw); err != nil {
 		return err
@@ -135,18 +137,25 @@ func setupNetworkCNI(n *object.Node, dir string, nw Networker) error {
 		return err
 	}
 	p := CNIConfigFile(dir, nw)
-	if file.Exists(p) {
-		nw.Log().Info().Msgf("cni %s is already setup", p)
-		return nil
-	}
 	nw.Log().Info().Msgf("cni %s write", p)
 	return writeCNIConfig(p, data)
 }
 
 func writeCNIConfig(fpath string, data interface{}) error {
+	tmp, err := os.CreateTemp(filepath.Dir(fpath), "."+filepath.Base(fpath)+".")
+	if err != nil {
+		return err
+	}
 	if b, err := json.MarshalIndent(data, "", "   "); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return err
+	} else if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
 		return err
 	} else {
-		return os.WriteFile(fpath, b, 0644)
+		_ = tmp.Close()
+		return os.Rename(tmp.Name(), fpath)
 	}
 }

--- a/core/network/setup.go
+++ b/core/network/setup.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,6 +67,12 @@ func checkOverlap(nw Networker, nws []Networker) error {
 	_, refIPNet, err := net.ParseCIDR(nw.Network())
 	if err != nil {
 		return nil
+	}
+	if prefix, err := netip.ParsePrefix(nw.Network()); err != nil {
+		return err
+	} else if prefix.Addr().String() != refIPNet.IP.String() {
+		// ex: 172.10.10.0/22 prefix addr 172.10.10.0 does not match the prefix length (expected 172.10.8.0)
+		return errors.Errorf("%s prefix addr %s does not match the prefix length (expected %s)", prefix, prefix.Addr(), refIPNet.IP)
 	}
 	for _, other := range nws {
 		if nw == other {

--- a/core/xconfig/main.go
+++ b/core/xconfig/main.go
@@ -1,6 +1,8 @@
 package xconfig
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -751,6 +753,18 @@ func (t *T) replaceReferences(v string, section string, impersonate string) (str
 		return s
 	})
 	return v, errs
+}
+
+func (t T) SectionSig(section string) string {
+	s, err := t.file.GetSection(section)
+	if err != nil {
+		return ""
+	}
+	sum := md5.New()
+	for _, k := range s.Keys() {
+		sum.Write([]byte(k.Value()))
+	}
+	return hex.EncodeToString(sum.Sum([]byte{}))
 }
 
 func (t T) SectionMap(section string) map[string]string {

--- a/daemon/ccfg/main.go
+++ b/daemon/ccfg/main.go
@@ -24,7 +24,9 @@ import (
 
 type (
 	ccfg struct {
-		state         cluster.Config
+		state       cluster.Config
+		networkSigs map[string]string
+
 		clusterConfig *xconfig.T
 		ctx           context.Context
 		cancel        context.CancelFunc
@@ -65,13 +67,14 @@ func Start(parent context.Context) error {
 	ctx, cancel := context.WithCancel(parent)
 
 	o := &ccfg{
-		ctx:       ctx,
-		cancel:    cancel,
-		cmdC:      make(chan any),
-		databus:   daemondata.FromContext(ctx),
-		bus:       pubsub.BusFromContext(ctx),
-		log:       log.Logger.With().Str("func", "ccfg").Logger(),
-		localhost: hostname.Hostname(),
+		networkSigs: make(map[string]string),
+		ctx:         ctx,
+		cancel:      cancel,
+		cmdC:        make(chan any),
+		databus:     daemondata.FromContext(ctx),
+		bus:         pubsub.BusFromContext(ctx),
+		log:         log.Logger.With().Str("func", "ccfg").Logger(),
+		localhost:   hostname.Hostname(),
 	}
 
 	if n, err := object.NewCluster(object.WithVolatile(true)); err != nil {

--- a/drivers/resipcni/main.go
+++ b/drivers/resipcni/main.go
@@ -172,7 +172,7 @@ func (t T) delObjectNetNS() error {
 
 func (t *T) StatusInfo() map[string]interface{} {
 	data := make(map[string]interface{})
-	if ip, _, err := t.ipNet(); err == nil {
+	if ip, _, err := t.ipNet(); (err == nil) && (len(ip) > 0) {
 		data["ipaddr"] = ip.String()
 	}
 	/*


### PR DESCRIPTION
- Fix a "net setup" error on link lookup with empty linkname
- Add a "net setup" test for wrongly prefixed network addresses
- Add initial routedbridge subnet allocations
- Rewrite the cni config on "net setup"
- Run network.Setup() on network config change
- Avoid exposing ipaddr=<nil> in ip.cni status info
